### PR TITLE
feat: updated api usage

### DIFF
--- a/frontend/src/api/events.ts
+++ b/frontend/src/api/events.ts
@@ -26,6 +26,11 @@ export interface EventDto {
 
 export type OptionalEvent = Partial<Event>;
 
+export interface PresignedUrl {
+  uploadLink: string;
+  objectKey: string;
+}
+
 const mapEventDtoToEvent = (event: EventDto): Event => ({
   ...event
 });
@@ -73,7 +78,7 @@ export const deleteEvent = (entryId: string) =>
   });
 
 export const getPresignedUrl = (entryId: string, fileName: string, uploadType: string) =>
-  createApi({
+  createApi<PresignedUrl>({
     method: 'put',
     authorize: true,
     url: `/events/${entryId}/upload/${uploadType}`,

--- a/frontend/src/api/utils/createApi.ts
+++ b/frontend/src/api/utils/createApi.ts
@@ -42,16 +42,11 @@ interface createApiProps<D, T = D> {
 
 export type GenericReturn<T> = AxiosResponse<T> & CustomAxiosError;
 
-export function createApi<D, T = D>({
-  method = 'get',
-  url,
-  authorize = false,
-  apiService = 'events',
-  queryParams = {},
-  body,
-  timeout = 1000 * 60,
-  output
-}: createApiProps<D, T>) {
+export function createApi<D, T = D>(
+  { method = 'get', url, authorize = false, apiService = 'events', queryParams = {}, body, timeout = 1000 * 60, output }: createApiProps<D, T>,
+  staleTime?: number,
+  cacheTime?: number
+) {
   const baseURL = apiService === 'events' ? import.meta.env.VITE_API_EVENTS_BASE_URL : import.meta.env.VITE_API_AUTH_BASE_URL;
   const api = axios.create();
   const queryFn = async (signal?: AbortSignal) => {
@@ -98,11 +93,15 @@ export function createApi<D, T = D>({
 
   return {
     queryKey: createQueryKey(url, body) as unknown as QueryKey,
-    queryFn
+    queryFn,
+    staleTime,
+    cacheTime
   };
 }
 
 export interface createApiReturn<T> {
   queryKey: QueryKey;
   queryFn: (signal?: AbortSignal) => Promise<T>;
+  staleTime?: number;
+  cacheTime?: number;
 }

--- a/frontend/src/api/utils/createApi.ts
+++ b/frontend/src/api/utils/createApi.ts
@@ -54,7 +54,7 @@ export function createApi<D, T = D>({
 }: createApiProps<D, T>) {
   const baseURL = apiService === 'events' ? import.meta.env.VITE_API_EVENTS_BASE_URL : import.meta.env.VITE_API_AUTH_BASE_URL;
   const api = axios.create();
-  const queryFn = async () => {
+  const queryFn = async (signal?: AbortSignal) => {
     const accessToken = getCookie('_auth')!;
     try {
       const response = await api({
@@ -64,6 +64,7 @@ export function createApi<D, T = D>({
         params: queryParams,
         data: body,
         timeout,
+        signal,
         headers: {
           'Content-Type': 'application/json',
           ...(authorize && {
@@ -103,5 +104,5 @@ export function createApi<D, T = D>({
 
 export interface createApiReturn<T> {
   queryKey: QueryKey;
-  queryFn: () => Promise<T>;
+  queryFn: (signal?: AbortSignal) => Promise<T>;
 }

--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { getPresignedUrl } from '@/api/events';
-import { useFetchQuery } from '@/hooks/useApi';
+import { useApi } from '@/hooks/useApi';
 import { useNotifyToast } from '@/hooks/useNotifyToast';
 import FileViewerComponent from './FileViewerComponent';
 import Input from './Input';
@@ -18,7 +18,7 @@ interface FileUploadProps {
 
 const FileUpload = ({ entryId, uploadType, setObjectKeyValue, setFileUrl, originalImage }: FileUploadProps) => {
   const { successToast, errorToast } = useNotifyToast();
-  const { fetchQuery } = useFetchQuery<any>();
+  const api = useApi();
   const [image, setImage] = useState<string>(originalImage || '');
   const [isLoading, setIsLoading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
@@ -37,7 +37,7 @@ const FileUpload = ({ entryId, uploadType, setObjectKeyValue, setFileUrl, origin
   };
 
   const getPresignedUrlTrigger = async (entryId: string, fileName: string, fileType: string) => {
-    const response = await fetchQuery(getPresignedUrl(entryId, fileName, fileType));
+    const response = await api.execute(getPresignedUrl(entryId, fileName, fileType));
     return response.data;
   };
 

--- a/frontend/src/context/QueryClientContext.tsx
+++ b/frontend/src/context/QueryClientContext.tsx
@@ -1,12 +1,17 @@
-import React, { ReactNode } from 'react';
+import { JSXElementConstructor, ReactNode, createContext } from 'react';
+import { ApiClient } from '@/hooks/useApi';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 interface ReactQueryProviderProps {
   children?: ReactNode;
 }
-
+export const ApiContext = createContext<ApiClient | undefined>(undefined);
 const queryClient = new QueryClient();
 
-export const ReactQueryProvider: React.JSXElementConstructor<ReactQueryProviderProps> = ({ children }: ReactQueryProviderProps) => {
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+export const ReactQueryProvider: JSXElementConstructor<ReactQueryProviderProps> = ({ children }: ReactQueryProviderProps) => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ApiContext.Provider value={new ApiClient(queryClient)}>{children}</ApiContext.Provider>
+    </QueryClientProvider>
+  );
 };

--- a/frontend/src/hooks/useAbortController.ts
+++ b/frontend/src/hooks/useAbortController.ts
@@ -1,0 +1,21 @@
+import { useRef, useEffect } from 'react';
+
+export const useAbortController = () => {
+  const abortController = useRef(new AbortController());
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!e.defaultPrevented) {
+        abortController.current.abort();
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      abortController.current.abort();
+    };
+  }, []);
+
+  return abortController.current;
+};

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -37,10 +37,6 @@ export class ApiClient {
   invalidateQueries<T>(request: createApiReturn<T>) {
     return this.queryClient.invalidateQueries(request.queryKey);
   }
-
-  refetchQueries<T>(request: createApiReturn<T>) {
-    return this.queryClient.refetchQueries(request.queryKey);
-  }
 }
 
 export const useApi = () => {

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -23,23 +23,23 @@ export const useApiQuery = <T>(request: createApiReturn<T>, { active = true, sus
 export class ApiClient {
   constructor(private queryClient: QueryClient) {}
 
-  execute<T>(api: createApiReturn<T>, signal?: AbortSignal) {
+  execute<T>(request: createApiReturn<T>, signal?: AbortSignal) {
     if (!this.queryClient) {
       throw new Error('QueryClient is not initialized');
     }
-    return api.queryFn(signal);
+    return request.queryFn(signal);
   }
 
-  query<T>(api: createApiReturn<T>, signal?: AbortSignal) {
-    return this.queryClient.fetchQuery(api.queryKey, () => this.execute(api, signal));
+  query<T>(request: createApiReturn<T>, signal?: AbortSignal) {
+    return this.queryClient.fetchQuery(request.queryKey, () => this.execute(request, signal), { staleTime: request.staleTime, cacheTime: request.cacheTime });
   }
 
-  invalidateQueries<T>(api: createApiReturn<T>) {
-    return this.queryClient.invalidateQueries(api.queryKey);
+  invalidateQueries<T>(request: createApiReturn<T>) {
+    return this.queryClient.invalidateQueries(request.queryKey);
   }
 
-  refetchQueries<T>(api: createApiReturn<T>) {
-    return this.queryClient.refetchQueries(api.queryKey);
+  refetchQueries<T>(request: createApiReturn<T>) {
+    return this.queryClient.refetchQueries(request.queryKey);
   }
 }
 

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,5 +1,7 @@
+import { useContext } from 'react';
 import { createApiReturn } from '@/api/utils/createApi';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { ApiContext } from '@/context/QueryClientContext';
+import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query';
 
 interface QueryOptions {
   active?: boolean;
@@ -7,8 +9,9 @@ interface QueryOptions {
   keepPreviousData?: boolean;
 }
 
-export const useApi = <T>(api: createApiReturn<T>, { active = true, suspense = false, keepPreviousData = false }: QueryOptions = {}) => {
-  return useQuery(api.queryKey, api.queryFn, {
+export const useApiQuery = <T>(request: createApiReturn<T>, { active = true, suspense = false, keepPreviousData = false }: QueryOptions = {}) => {
+  const api = useApi();
+  return useQuery(request.queryKey, ({ signal }) => api.execute(request, signal), {
     enabled: active,
     suspense,
     keepPreviousData,
@@ -17,8 +20,34 @@ export const useApi = <T>(api: createApiReturn<T>, { active = true, suspense = f
   });
 };
 
-export const useFetchQuery = <T>() => {
-  const queryClient = useQueryClient();
-  const fetchQuery = async (api: createApiReturn<T>) => await queryClient.fetchQuery(api.queryKey, api.queryFn);
-  return { fetchQuery };
+export class ApiClient {
+  constructor(private queryClient: QueryClient) {}
+
+  execute<T>(api: createApiReturn<T>, signal?: AbortSignal) {
+    if (!this.queryClient) {
+      throw new Error('QueryClient is not initialized');
+    }
+    return api.queryFn(signal);
+  }
+
+  query<T>(api: createApiReturn<T>, signal?: AbortSignal) {
+    return this.queryClient.fetchQuery(api.queryKey, () => this.execute(api, signal));
+  }
+
+  invalidateQueries<T>(api: createApiReturn<T>) {
+    return this.queryClient.invalidateQueries(api.queryKey);
+  }
+
+  refetchQueries<T>(api: createApiReturn<T>) {
+    return this.queryClient.refetchQueries(api.queryKey);
+  }
+}
+
+export const useApi = () => {
+  const client = useContext(ApiContext);
+  if (!client) {
+    throw new Error('useApi should be used within a QueryClientProvider');
+  }
+
+  return client;
 };

--- a/frontend/src/hooks/useMetaData.ts
+++ b/frontend/src/hooks/useMetaData.ts
@@ -1,0 +1,15 @@
+interface Props {
+  title?: string;
+  iconUrl?: string;
+}
+
+export const useMetaData = ({ title, iconUrl }: Props) => {
+  if (title) {
+    document.title = title;
+  }
+
+  const link = document.querySelector('link[rel="icon"]');
+  if (link && iconUrl) {
+    link.setAttribute('href', iconUrl);
+  }
+};

--- a/frontend/src/pages/admin/event/allEvents/AdminAllEventsPage.tsx
+++ b/frontend/src/pages/admin/event/allEvents/AdminAllEventsPage.tsx
@@ -14,7 +14,7 @@ import { Textarea } from '@/components/TextArea';
 import { getAllEvents, deleteEvent } from '@/api/events';
 import { Event } from '@/model/events';
 import { useAdminEventForm } from '@/hooks/useAdminEventForm';
-import { useApi, useFetchQuery } from '@/hooks/useApi';
+import { useApiQuery, useApi } from '@/hooks/useApi';
 
 const CreateEventModal = ({ refetch }: { refetch: () => void }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -126,12 +126,12 @@ const CardHeader: React.FC<CardHeaderProps> = ({ eventInfo, refetch }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const closeModal = () => setIsModalOpen(false);
-  const { fetchQuery } = useFetchQuery();
+  const api = useApi();
   const deleteEventTrigger = async () => {
     if (eventInfo.entryId === undefined) {
       return;
     }
-    await fetchQuery(deleteEvent(eventInfo.entryId));
+    await api.execute(deleteEvent(eventInfo.entryId));
     refetch();
     closeModal();
   };
@@ -153,7 +153,7 @@ const CardHeader: React.FC<CardHeaderProps> = ({ eventInfo, refetch }) => {
 };
 
 const AdminAllEvents = () => {
-  const { data: response, isFetching, refetch } = useApi(getAllEvents());
+  const { data: response, isFetching, refetch } = useApiQuery(getAllEvents());
 
   if (isFetching) {
     return (

--- a/frontend/src/pages/admin/event/event/AdminEventDiscounts.tsx
+++ b/frontend/src/pages/admin/event/event/AdminEventDiscounts.tsx
@@ -7,7 +7,7 @@ import Input from '@/components/Input';
 import Modal from '@/components/Modal';
 import { getAllDiscounts } from '@/api/discounts';
 import { Discount } from '@/model/discount';
-import { useApi } from '@/hooks/useApi';
+import { useApiQuery } from '@/hooks/useApi';
 import { useDiscountForm } from '@/hooks/useDiscountForm';
 import { discountColumns } from './DiscountColumns';
 
@@ -107,7 +107,7 @@ interface Props {
   eventId?: string;
 }
 const AdminEventDiscounts: FC<Props> = ({ eventId }) => {
-  const { data: response, isFetching, refetch } = useApi(getAllDiscounts(eventId!));
+  const { data: response, isFetching, refetch } = useApiQuery(getAllDiscounts(eventId!));
 
   if (!eventId) {
     return <h1>Event not found</h1>;

--- a/frontend/src/pages/admin/event/event/AdminEventEvaluations.tsx
+++ b/frontend/src/pages/admin/event/event/AdminEventEvaluations.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { DataTable } from '@/components/DataTable';
 import { getEvaluations } from '@/api/evaluations';
-import { useApi } from '@/hooks/useApi';
+import { useApiQuery } from '@/hooks/useApi';
 import { evaluationColumns } from './EvaluationColumns';
 
 interface Props {
@@ -9,7 +9,7 @@ interface Props {
 }
 
 const AdminEventeEvaluations: FC<Props> = ({ eventId }) => {
-  const { data: response, isFetching } = useApi(getEvaluations(eventId!));
+  const { data: response, isFetching } = useApiQuery(getEvaluations(eventId!));
 
   if (!eventId) {
     return <h1>Event not found</h1>;

--- a/frontend/src/pages/admin/event/event/AdminEventPageContent.tsx
+++ b/frontend/src/pages/admin/event/event/AdminEventPageContent.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/Tabs';
 import { getEvent } from '@/api/events';
-import { useApi } from '@/hooks/useApi';
+import { useApiQuery } from '@/hooks/useApi';
 import AdminEventDiscounts from './AdminEventDiscounts';
 import AdminEventEvaluations from './AdminEventEvaluations';
 import AdminEventInfo from './AdminEventInfo';
@@ -9,7 +9,7 @@ import AdminEventRegistrations from './AdminEventRegistrations';
 
 const AdminEventPageContent = () => {
   const { eventId } = useParams();
-  const { data: response, isFetching } = useApi(getEvent(eventId!));
+  const { data: response, isFetching } = useApiQuery(getEvent(eventId!));
 
   if (isFetching) {
     return (

--- a/frontend/src/pages/admin/event/event/AdminEventRegistrations.tsx
+++ b/frontend/src/pages/admin/event/event/AdminEventRegistrations.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { DataTable } from '@/components/DataTable';
 import { getEventRegistrations } from '@/api/registrations';
-import { useApi } from '@/hooks/useApi';
+import { useApiQuery } from '@/hooks/useApi';
 import { registrationColumns } from './RegistrationsColumns';
 
 interface Props {
@@ -11,7 +11,7 @@ interface Props {
 const AdminEventRegistrations: FC<Props> = ({ eventId }) => {
   // TODO: Implement table
 
-  const { data: response, isFetching } = useApi(getEventRegistrations(eventId!));
+  const { data: response, isFetching } = useApiQuery(getEventRegistrations(eventId!));
 
   if (!eventId) {
     return <h1>Event not found</h1>;

--- a/frontend/src/pages/evaluate/Evaluate.tsx
+++ b/frontend/src/pages/evaluate/Evaluate.tsx
@@ -8,9 +8,10 @@ import Icon from '@/components/Icon';
 import Separator from '@/components/Separator';
 import { getEvent } from '@/api/events';
 import { isEmpty } from '@/utils/functions';
-import { useApi } from '@/hooks/useApi';
+import { useApiQuery } from '@/hooks/useApi';
 import { useCheckEmailForm } from '@/hooks/useCheckEmailForm';
 import { QuestionSchemaBuilder, useEvaluationForm } from '@/hooks/useEvaluationForm';
+import { useMetaData } from '@/hooks/useMetaData';
 import QuestionBuilder from '../evaluate/QuestionBuilder';
 import CertificateClaim from './CertificateClaim';
 import EvaluateFormSkeleton from './EvalauteFormSkeleton';
@@ -26,7 +27,7 @@ const EVALUATIONS_FORM_STEPS = ['Evaluation_1', 'Evaluation_2'];
 const Evaluate = () => {
   const [currentStep, setCurrentStep] = useState<EvaluateSteps>(EVALUATE_STEPS[0]);
   const eventId = useParams().eventId!;
-  const { data: eventResponse, isFetching } = useApi(getEvent(eventId!));
+  const { data: eventResponse, isFetching } = useApiQuery(getEvent(eventId!));
 
   const evaluationSchema = QuestionSchemaBuilder([...question1, ...question2]);
   type EvaluationField = keyof z.infer<typeof evaluationSchema> & string;
@@ -96,12 +97,10 @@ const Evaluate = () => {
 
   const eventInfo = eventResponse.data;
 
-  document.title = eventInfo.name;
-  const link = document.querySelector('link[rel="icon"]');
-
-  if (link && eventInfo.logoUrl) {
-    link.setAttribute('href', eventInfo.logoUrl);
-  }
+  useMetaData({
+    title: eventInfo.name,
+    iconUrl: eventInfo.logoUrl
+  });
 
   if (postEvalSuccess) {
     nextStep();


### PR DESCRIPTION
**`useApiQuery`** = using `useQuery` in react query

**`api = useApi `** = using the `queryClient` instance but limited to 4 methods such as:

- **`execute`**: basically calls the api without react query
- **`query`**: sort of the same as `useQuery`. Just not using the hook version
- **`invalidateQueries`**: invalidates the current data from the query and refetches in the background