### PR TITLE
271 be add export as csv api for registrations for events service

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -8,3 +8,4 @@ node_modules
 .env
 .env.*
 .ruff_cache
+pyrightconfig.json

--- a/backend/controller/preregistration_router.py
+++ b/backend/controller/preregistration_router.py
@@ -243,7 +243,7 @@ def delete_preregistration(
 
 
 @preregistration_router.get(
-    '/{entryId}/csv_download',
+    '/{eventId}/csv_download',
     response_model=FileDownloadOut,
     responses={
         404: {'model': Message, 'description': 'Pre-registration not found'},
@@ -262,9 +262,6 @@ def get_preregistration_csv(
     event_id: str = Path(..., title='Event Id', alias=CommonConstants.EVENT_ID),
 ):
     """Get the CSV for a specific event
-
-    :param entry_id: The pre-registration ID.
-    :type entry_id: str
 
     :param event_id: The event ID.
     :type event_id: str

--- a/backend/controller/preregistration_router.py
+++ b/backend/controller/preregistration_router.py
@@ -286,3 +286,4 @@ def get_preregistration_csv(
 
     """
     preregistrations_uc = PreRegistrationUsecase()
+    return preregistrations_uc.get_preregistration_csv(event_id=event_id)

--- a/backend/controller/preregistration_router.py
+++ b/backend/controller/preregistration_router.py
@@ -10,6 +10,7 @@ from model.preregistrations.preregistration import (
     PreRegistrationOut,
     PreRegistrationPatch,
 )
+from model.file_uploads.file_upload import FileDownloadOut
 from pydantic import EmailStr
 from usecase.preregistration_usecase import PreRegistrationUsecase
 
@@ -17,23 +18,23 @@ preregistration_router = APIRouter()
 
 
 @preregistration_router.get(
-    '',
+    "",
     response_model=List[PreRegistrationOut],
     responses={
-        404: {'model': Message, 'description': 'Pre-registration not found'},
-        500: {'model': Message, 'description': 'Internal server error'},
+        404: {"model": Message, "description": "Pre-registration not found"},
+        500: {"model": Message, "description": "Internal server error"},
     },
-    summary='Get pre-registrations',
+    summary="Get pre-registrations",
 )
 @preregistration_router.get(
-    '/',
+    "/",
     response_model=List[PreRegistrationOut],
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
     include_in_schema=False,
 )
 def get_preregistrations(
-    event_id: str = Query(None, title='Event Id', alias=CommonConstants.EVENT_ID),
+    event_id: str = Query(None, title="Event Id", alias=CommonConstants.EVENT_ID),
 ):
     """Get a list of pre-registration entries
 
@@ -49,24 +50,26 @@ def get_preregistrations(
 
 
 @preregistration_router.get(
-    '/{entryId}',
+    "/{entryId}",
     response_model=PreRegistrationOut,
     responses={
-        404: {'model': Message, 'description': 'Pre-registration not found'},
-        500: {'model': Message, 'description': 'Internal server error'},
+        404: {"model": Message, "description": "Pre-registration not found"},
+        500: {"model": Message, "description": "Internal server error"},
     },
-    summary='Get pre-registration',
+    summary="Get pre-registration",
 )
 @preregistration_router.get(
-    '/{entryId}/',
+    "/{entryId}/",
     response_model=PreRegistrationOut,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
     include_in_schema=False,
 )
 def get_preregistration(
-    entry_id: str = Path(..., title='Pre-registration Id', alias=CommonConstants.ENTRY_ID),
-    event_id: str = Query(..., title='Event Id', alias=CommonConstants.EVENT_ID),
+    entry_id: str = Path(
+        ..., title="Pre-registration Id", alias=CommonConstants.ENTRY_ID
+    ),
+    event_id: str = Query(..., title="Event Id", alias=CommonConstants.EVENT_ID),
 ):
     """Get a specific pre-registration entry by its ID.
 
@@ -81,28 +84,30 @@ def get_preregistration(
 
     """
     preregistrations_uc = PreRegistrationUsecase()
-    return preregistrations_uc.get_preregistration(event_id=event_id, preregistration_id=entry_id)
+    return preregistrations_uc.get_preregistration(
+        event_id=event_id, preregistration_id=entry_id
+    )
 
 
 @preregistration_router.get(
-    '/{email}/email',
+    "/{email}/email",
     response_model=PreRegistrationOut,
     responses={
-        404: {'model': Message, 'description': 'Pre-registration not found'},
-        500: {'model': Message, 'description': 'Internal server error'},
+        404: {"model": Message, "description": "Pre-registration not found"},
+        500: {"model": Message, "description": "Internal server error"},
     },
-    summary='Get pre-registration',
+    summary="Get pre-registration",
 )
 @preregistration_router.get(
-    '/{email}/email/',
+    "/{email}/email/",
     response_model=PreRegistrationOut,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
     include_in_schema=False,
 )
 def get_preregistration_by_email(
-    email: EmailStr = Path(..., title='Email'),
-    event_id: str = Query(..., title='Event Id', alias=CommonConstants.EVENT_ID),
+    email: EmailStr = Path(..., title="Email"),
+    event_id: str = Query(..., title="Event Id", alias=CommonConstants.EVENT_ID),
 ):
     """Get a specific pre-registration email used.
 
@@ -114,24 +119,26 @@ def get_preregistration_by_email(
 
     """
     preregistrations_uc = PreRegistrationUsecase()
-    return preregistrations_uc.get_preregistration_by_email(event_id=event_id, email=email)
+    return preregistrations_uc.get_preregistration_by_email(
+        event_id=event_id, email=email
+    )
 
 
 @preregistration_router.post(
-    '',
+    "",
     response_model=PreRegistrationOut,
     responses={
-        400: {'model': Message, 'description': 'Invalid input'},
+        400: {"model": Message, "description": "Invalid input"},
         409: {
-            'model': Message,
-            'description': 'Pre-registration with email example@example.com already exists',
+            "model": Message,
+            "description": "Pre-registration with email example@example.com already exists",
         },
-        500: {'model': Message, 'description': 'Internal server error'},
+        500: {"model": Message, "description": "Internal server error"},
     },
-    summary='Create pre-registration',
+    summary="Create pre-registration",
 )
 @preregistration_router.post(
-    '/',
+    "/",
     response_model=PreRegistrationOut,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
@@ -154,17 +161,17 @@ def create_preregistration(
 
 
 @preregistration_router.put(
-    '/{entryId}',
+    "/{entryId}",
     response_model=PreRegistrationOut,
     responses={
-        400: {'model': Message, 'description': 'Bad request'},
-        404: {'model': Message, 'description': 'Pre-registration not found'},
-        500: {'model': Message, 'description': 'Internal server error'},
+        400: {"model": Message, "description": "Bad request"},
+        404: {"model": Message, "description": "Pre-registration not found"},
+        500: {"model": Message, "description": "Internal server error"},
     },
-    summary='Update pre-registration',
+    summary="Update pre-registration",
 )
 @preregistration_router.put(
-    '/{entryId}/',
+    "/{entryId}/",
     response_model=PreRegistrationOut,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
@@ -172,8 +179,10 @@ def create_preregistration(
 )
 def update_preregistration(
     preregistration: PreRegistrationPatch,
-    entry_id: str = Path(..., title='Pre-registration Id', alias=CommonConstants.ENTRY_ID),
-    event_id: str = Query(..., title='Event Id', alias=CommonConstants.EVENT_ID),
+    entry_id: str = Path(
+        ..., title="Pre-registration Id", alias=CommonConstants.ENTRY_ID
+    ),
+    event_id: str = Query(..., title="Event Id", alias=CommonConstants.EVENT_ID),
     current_user: AccessUser = Depends(get_current_user),
 ):
     """Update an existing pre-registration entry.
@@ -197,26 +206,30 @@ def update_preregistration(
     _ = current_user
     preregistrations_uc = PreRegistrationUsecase()
     return preregistrations_uc.update_preregistration(
-        event_id=event_id, preregistration_id=entry_id, preregistration_in=preregistration
+        event_id=event_id,
+        preregistration_id=entry_id,
+        preregistration_in=preregistration,
     )
 
 
 @preregistration_router.delete(
-    '/{entryId}',
+    "/{entryId}",
     status_code=HTTPStatus.NO_CONTENT,
     responses={
-        204: {'description': 'Pre-registration deletion success', 'content': None},
+        204: {"description": "Pre-registration deletion success", "content": None},
     },
-    summary='Delete pre-registration',
+    summary="Delete pre-registration",
 )
 @preregistration_router.delete(
-    '{entryId}/',
+    "{entryId}/",
     status_code=HTTPStatus.NO_CONTENT,
     include_in_schema=False,
 )
 def delete_preregistration(
-    entry_id: str = Path(..., title='Pre-registration Id', alias=CommonConstants.ENTRY_ID),
-    event_id: str = Query(..., title='Event Id', alias=CommonConstants.EVENT_ID),
+    entry_id: str = Path(
+        ..., title="Pre-registration Id", alias=CommonConstants.ENTRY_ID
+    ),
+    event_id: str = Query(..., title="Event Id", alias=CommonConstants.EVENT_ID),
     current_user: AccessUser = Depends(get_current_user),
 ):
     """Delete a specific registration entry by its ID.
@@ -236,4 +249,40 @@ def delete_preregistration(
     """
     _ = current_user
     preregistrations_uc = PreRegistrationUsecase()
-    return preregistrations_uc.delete_preregistration(preregistration_id=entry_id, event_id=event_id)
+    return preregistrations_uc.delete_preregistration(
+        preregistration_id=entry_id, event_id=event_id
+    )
+
+
+@preregistration_router.get(
+    "/{entryId}/csv_download",
+    response_model=FileDownloadOut,
+    responses={
+        404: {"model": Message, "description": "Pre-registration not found"},
+        500: {"model": Message, "description": "Internal server error"},
+    },
+    summary="Get CSV for pre-registration",
+)
+@preregistration_router.get(
+    "/{eventId}/csv_download/",
+    response_model=FileDownloadOut,
+    response_model_exclude_none=True,
+    response_model_exclude_unset=True,
+    include_in_schema=False,
+)
+def get_preregistration_csv(
+    event_id: str = Path(..., title="Event Id", alias=CommonConstants.EVENT_ID),
+):
+    """Get the CSV for a specific event
+
+    :param entry_id: The pre-registration ID.
+    :type entry_id: str
+
+    :param event_id: The event ID.
+    :type event_id: str
+
+    :return: The csv for the corresponding event
+    :rtype: FileDownloadOut
+
+    """
+    pass

--- a/backend/controller/preregistration_router.py
+++ b/backend/controller/preregistration_router.py
@@ -285,4 +285,4 @@ def get_preregistration_csv(
     :rtype: FileDownloadOut
 
     """
-    pass
+    preregistrations_uc = PreRegistrationUsecase()

--- a/backend/controller/preregistration_router.py
+++ b/backend/controller/preregistration_router.py
@@ -5,12 +5,12 @@ from aws.cognito_settings import AccessUser, get_current_user
 from constants.common_constants import CommonConstants
 from fastapi import APIRouter, Depends, Path, Query
 from model.common import Message
+from model.file_uploads.file_upload import FileDownloadOut
 from model.preregistrations.preregistration import (
     PreRegistrationIn,
     PreRegistrationOut,
     PreRegistrationPatch,
 )
-from model.file_uploads.file_upload import FileDownloadOut
 from pydantic import EmailStr
 from usecase.preregistration_usecase import PreRegistrationUsecase
 
@@ -18,23 +18,23 @@ preregistration_router = APIRouter()
 
 
 @preregistration_router.get(
-    "",
+    '',
     response_model=List[PreRegistrationOut],
     responses={
-        404: {"model": Message, "description": "Pre-registration not found"},
-        500: {"model": Message, "description": "Internal server error"},
+        404: {'model': Message, 'description': 'Pre-registration not found'},
+        500: {'model': Message, 'description': 'Internal server error'},
     },
-    summary="Get pre-registrations",
+    summary='Get pre-registrations',
 )
 @preregistration_router.get(
-    "/",
+    '/',
     response_model=List[PreRegistrationOut],
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
     include_in_schema=False,
 )
 def get_preregistrations(
-    event_id: str = Query(None, title="Event Id", alias=CommonConstants.EVENT_ID),
+    event_id: str = Query(None, title='Event Id', alias=CommonConstants.EVENT_ID),
 ):
     """Get a list of pre-registration entries
 
@@ -50,26 +50,24 @@ def get_preregistrations(
 
 
 @preregistration_router.get(
-    "/{entryId}",
+    '/{entryId}',
     response_model=PreRegistrationOut,
     responses={
-        404: {"model": Message, "description": "Pre-registration not found"},
-        500: {"model": Message, "description": "Internal server error"},
+        404: {'model': Message, 'description': 'Pre-registration not found'},
+        500: {'model': Message, 'description': 'Internal server error'},
     },
-    summary="Get pre-registration",
+    summary='Get pre-registration',
 )
 @preregistration_router.get(
-    "/{entryId}/",
+    '/{entryId}/',
     response_model=PreRegistrationOut,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
     include_in_schema=False,
 )
 def get_preregistration(
-    entry_id: str = Path(
-        ..., title="Pre-registration Id", alias=CommonConstants.ENTRY_ID
-    ),
-    event_id: str = Query(..., title="Event Id", alias=CommonConstants.EVENT_ID),
+    entry_id: str = Path(..., title='Pre-registration Id', alias=CommonConstants.ENTRY_ID),
+    event_id: str = Query(..., title='Event Id', alias=CommonConstants.EVENT_ID),
 ):
     """Get a specific pre-registration entry by its ID.
 
@@ -84,30 +82,28 @@ def get_preregistration(
 
     """
     preregistrations_uc = PreRegistrationUsecase()
-    return preregistrations_uc.get_preregistration(
-        event_id=event_id, preregistration_id=entry_id
-    )
+    return preregistrations_uc.get_preregistration(event_id=event_id, preregistration_id=entry_id)
 
 
 @preregistration_router.get(
-    "/{email}/email",
+    '/{email}/email',
     response_model=PreRegistrationOut,
     responses={
-        404: {"model": Message, "description": "Pre-registration not found"},
-        500: {"model": Message, "description": "Internal server error"},
+        404: {'model': Message, 'description': 'Pre-registration not found'},
+        500: {'model': Message, 'description': 'Internal server error'},
     },
-    summary="Get pre-registration",
+    summary='Get pre-registration',
 )
 @preregistration_router.get(
-    "/{email}/email/",
+    '/{email}/email/',
     response_model=PreRegistrationOut,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
     include_in_schema=False,
 )
 def get_preregistration_by_email(
-    email: EmailStr = Path(..., title="Email"),
-    event_id: str = Query(..., title="Event Id", alias=CommonConstants.EVENT_ID),
+    email: EmailStr = Path(..., title='Email'),
+    event_id: str = Query(..., title='Event Id', alias=CommonConstants.EVENT_ID),
 ):
     """Get a specific pre-registration email used.
 
@@ -119,26 +115,24 @@ def get_preregistration_by_email(
 
     """
     preregistrations_uc = PreRegistrationUsecase()
-    return preregistrations_uc.get_preregistration_by_email(
-        event_id=event_id, email=email
-    )
+    return preregistrations_uc.get_preregistration_by_email(event_id=event_id, email=email)
 
 
 @preregistration_router.post(
-    "",
+    '',
     response_model=PreRegistrationOut,
     responses={
-        400: {"model": Message, "description": "Invalid input"},
+        400: {'model': Message, 'description': 'Invalid input'},
         409: {
-            "model": Message,
-            "description": "Pre-registration with email example@example.com already exists",
+            'model': Message,
+            'description': 'Pre-registration with email example@example.com already exists',
         },
-        500: {"model": Message, "description": "Internal server error"},
+        500: {'model': Message, 'description': 'Internal server error'},
     },
-    summary="Create pre-registration",
+    summary='Create pre-registration',
 )
 @preregistration_router.post(
-    "/",
+    '/',
     response_model=PreRegistrationOut,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
@@ -161,17 +155,17 @@ def create_preregistration(
 
 
 @preregistration_router.put(
-    "/{entryId}",
+    '/{entryId}',
     response_model=PreRegistrationOut,
     responses={
-        400: {"model": Message, "description": "Bad request"},
-        404: {"model": Message, "description": "Pre-registration not found"},
-        500: {"model": Message, "description": "Internal server error"},
+        400: {'model': Message, 'description': 'Bad request'},
+        404: {'model': Message, 'description': 'Pre-registration not found'},
+        500: {'model': Message, 'description': 'Internal server error'},
     },
-    summary="Update pre-registration",
+    summary='Update pre-registration',
 )
 @preregistration_router.put(
-    "/{entryId}/",
+    '/{entryId}/',
     response_model=PreRegistrationOut,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
@@ -179,10 +173,8 @@ def create_preregistration(
 )
 def update_preregistration(
     preregistration: PreRegistrationPatch,
-    entry_id: str = Path(
-        ..., title="Pre-registration Id", alias=CommonConstants.ENTRY_ID
-    ),
-    event_id: str = Query(..., title="Event Id", alias=CommonConstants.EVENT_ID),
+    entry_id: str = Path(..., title='Pre-registration Id', alias=CommonConstants.ENTRY_ID),
+    event_id: str = Query(..., title='Event Id', alias=CommonConstants.EVENT_ID),
     current_user: AccessUser = Depends(get_current_user),
 ):
     """Update an existing pre-registration entry.
@@ -213,23 +205,21 @@ def update_preregistration(
 
 
 @preregistration_router.delete(
-    "/{entryId}",
+    '/{entryId}',
     status_code=HTTPStatus.NO_CONTENT,
     responses={
-        204: {"description": "Pre-registration deletion success", "content": None},
+        204: {'description': 'Pre-registration deletion success', 'content': None},
     },
-    summary="Delete pre-registration",
+    summary='Delete pre-registration',
 )
 @preregistration_router.delete(
-    "{entryId}/",
+    '{entryId}/',
     status_code=HTTPStatus.NO_CONTENT,
     include_in_schema=False,
 )
 def delete_preregistration(
-    entry_id: str = Path(
-        ..., title="Pre-registration Id", alias=CommonConstants.ENTRY_ID
-    ),
-    event_id: str = Query(..., title="Event Id", alias=CommonConstants.EVENT_ID),
+    entry_id: str = Path(..., title='Pre-registration Id', alias=CommonConstants.ENTRY_ID),
+    event_id: str = Query(..., title='Event Id', alias=CommonConstants.EVENT_ID),
     current_user: AccessUser = Depends(get_current_user),
 ):
     """Delete a specific registration entry by its ID.
@@ -249,29 +239,27 @@ def delete_preregistration(
     """
     _ = current_user
     preregistrations_uc = PreRegistrationUsecase()
-    return preregistrations_uc.delete_preregistration(
-        preregistration_id=entry_id, event_id=event_id
-    )
+    return preregistrations_uc.delete_preregistration(preregistration_id=entry_id, event_id=event_id)
 
 
 @preregistration_router.get(
-    "/{entryId}/csv_download",
+    '/{entryId}/csv_download',
     response_model=FileDownloadOut,
     responses={
-        404: {"model": Message, "description": "Pre-registration not found"},
-        500: {"model": Message, "description": "Internal server error"},
+        404: {'model': Message, 'description': 'Pre-registration not found'},
+        500: {'model': Message, 'description': 'Internal server error'},
     },
-    summary="Get CSV for pre-registration",
+    summary='Get CSV for pre-registration',
 )
 @preregistration_router.get(
-    "/{eventId}/csv_download/",
+    '/{eventId}/csv_download/',
     response_model=FileDownloadOut,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
     include_in_schema=False,
 )
 def get_preregistration_csv(
-    event_id: str = Path(..., title="Event Id", alias=CommonConstants.EVENT_ID),
+    event_id: str = Path(..., title='Event Id', alias=CommonConstants.EVENT_ID),
 ):
     """Get the CSV for a specific event
 

--- a/backend/controller/registration_router.py
+++ b/backend/controller/registration_router.py
@@ -214,5 +214,5 @@ def get_registration_csv(
     :rtype: FileDownloadOut
 
     """
-    preregistrations_uc = RegistrationUsecase()
-    return preregistrations_uc.get_registration_csv(event_id=event_id)
+    registrations_uc = RegistrationUsecase()
+    return registrations_uc.get_registration_csv(event_id=event_id)

--- a/backend/controller/registration_router.py
+++ b/backend/controller/registration_router.py
@@ -1,11 +1,11 @@
 from http import HTTPStatus
 from typing import List
 
-from model.file_uploads.file_upload import FileDownloadOut
 from aws.cognito_settings import AccessUser, get_current_user
 from constants.common_constants import CommonConstants
 from fastapi import APIRouter, Depends, Path, Query
 from model.common import Message
+from model.file_uploads.file_upload import FileDownloadOut
 from model.registrations.registration import (
     RegistrationIn,
     RegistrationOut,

--- a/backend/controller/registration_router.py
+++ b/backend/controller/registration_router.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 from typing import List
 
+from model.file_uploads.file_upload import FileDownloadOut
 from aws.cognito_settings import AccessUser, get_current_user
 from constants.common_constants import CommonConstants
 from fastapi import APIRouter, Depends, Path, Query
@@ -183,3 +184,35 @@ def delete_registration(
     _ = current_user
     registrations_uc = RegistrationUsecase()
     return registrations_uc.delete_registration(registration_id=entry_id, event_id=event_id)
+
+
+@registration_router.get(
+    '/{eventId}/csv_download',
+    response_model=FileDownloadOut,
+    responses={
+        404: {'model': Message, 'description': 'Registration not found'},
+        500: {'model': Message, 'description': 'Internal server error'},
+    },
+    summary='Get CSV for registration',
+)
+@registration_router.get(
+    '/{eventId}/csv_download/',
+    response_model=FileDownloadOut,
+    response_model_exclude_none=True,
+    response_model_exclude_unset=True,
+    include_in_schema=False,
+)
+def get_registration_csv(
+    event_id: str = Path(..., title='Event Id', alias=CommonConstants.EVENT_ID),
+):
+    """Get the CSV for a specific event
+
+    :param event_id: The event ID.
+    :type event_id: str
+
+    :return: The csv for the corresponding event
+    :rtype: FileDownloadOut
+
+    """
+    preregistrations_uc = RegistrationUsecase()
+    return preregistrations_uc.get_registration_csv(event_id=event_id)

--- a/backend/model/preregistrations/preregistration.py
+++ b/backend/model/preregistrations/preregistration.py
@@ -11,7 +11,7 @@ from pynamodb.models import Model
 
 class PreRegistrationGlobalSecondaryIndex(GlobalSecondaryIndex):
     class Meta:
-        index_name = 'PreRegistrationIdIndex'
+        index_name = "PreRegistrationIdIndex"
         projection = AllProjection()
         read_capacity_units = 1
         write_capacity_units = 1
@@ -21,7 +21,7 @@ class PreRegistrationGlobalSecondaryIndex(GlobalSecondaryIndex):
 
 class EmailLSI(LocalSecondaryIndex):
     class Meta:
-        index_name = 'EmailIndex'
+        index_name = "EmailIndex"
         projection = AllProjection()
         read_capacity_units = 1
         write_capacity_units = 1
@@ -32,9 +32,9 @@ class EmailLSI(LocalSecondaryIndex):
 
 class PreRegistration(Model):
     class Meta:
-        table_name = os.getenv('PREREGISTRATIONS_TABLE')
-        region = os.getenv('REGION')
-        billing_mode = 'PAY_PER_REQUEST'
+        table_name = os.getenv("PREREGISTRATIONS_TABLE")
+        region = os.getenv("REGION")
+        billing_mode = "PAY_PER_REQUEST"
 
     hashKey = UnicodeAttribute(hash_key=True)
     rangeKey = UnicodeAttribute(range_key=True)
@@ -67,47 +67,51 @@ class PreRegistrationaDataIn(BaseModel):
     class Config:
         extra = Extra.ignore
 
-    firstName: str = Field(None, title='First Name')
-    lastName: str = Field(None, title='Last Name')
-    contactNumber: str = Field(None, title='Contact Number')
-    careerStatus: str = Field(None, title='Career Status')
-    yearsOfExperience: str = Field(None, title='Years of Experience')
-    organization: str = Field(None, title='Organization')
-    title: str = Field(None, title='Title')
+    firstName: str = Field(None, title="First Name")
+    lastName: str = Field(None, title="Last Name")
+    contactNumber: str = Field(None, title="Contact Number")
+    careerStatus: str = Field(None, title="Career Status")
+    yearsOfExperience: str = Field(None, title="Years of Experience")
+    organization: str = Field(None, title="Organization")
+    title: str = Field(None, title="Title")
 
 
 class PreRegistrationPatch(PreRegistrationaDataIn):
     class Config:
         extra = Extra.forbid
 
-    acceptanceStatus: Optional[AcceptanceStatus] = Field(None, title='Acceptance Status')
-    acceptanceEmailSent: bool = Field(None, title='Acceptance Email Sent')
+    acceptanceStatus: Optional[AcceptanceStatus] = Field(
+        None, title="Acceptance Status"
+    )
+    acceptanceEmailSent: bool = Field(None, title="Acceptance Email Sent")
 
 
 class PreRegistrationIn(PreRegistrationaDataIn):
     class Config:
         extra = Extra.forbid
 
-    email: EmailStr = Field(None, title='Email')
-    eventId: str = Field(None, title='Event ID')
+    email: EmailStr = Field(None, title="Email")
+    eventId: str = Field(None, title="Event ID")
 
 
 class PreRegistrationOut(PreRegistrationIn):
     class Config:
         extra = Extra.ignore
 
-    preRegistrationId: str = Field(..., title='ID')
-    acceptanceEmailSent: bool = Field(None, title='Acceptance Email Sent')
-    acceptanceStatus: Optional[AcceptanceStatus] = Field(None, title='Acceptance Status')
-    createDate: datetime = Field(..., title='Created At')
-    updateDate: datetime = Field(..., title='Updated At')
+    preRegistrationId: str = Field(..., title="ID")
+    acceptanceEmailSent: bool = Field(None, title="Acceptance Email Sent")
+    acceptanceStatus: Optional[AcceptanceStatus] = Field(
+        None, title="Acceptance Status"
+    )
+    createDate: datetime = Field(..., title="Created At")
+    updateDate: datetime = Field(..., title="Updated At")
 
 
 class PreRegistrationPreviewOut(BaseModel):
     class Config:
         extra = Extra.ignore
 
-    firstName: str = Field(None, title='First Name')
-    lastName: str = Field(None, title='Last Name')
-    contactNumber: str = Field(None, title='Contact Number')
-    email: EmailStr = Field(None, title='Email')
+    firstName: str = Field(None, title="First Name")
+    lastName: str = Field(None, title="Last Name")
+    contactNumber: str = Field(None, title="Contact Number")
+    email: EmailStr = Field(None, title="Email")

--- a/backend/model/preregistrations/preregistration.py
+++ b/backend/model/preregistrations/preregistration.py
@@ -11,7 +11,7 @@ from pynamodb.models import Model
 
 class PreRegistrationGlobalSecondaryIndex(GlobalSecondaryIndex):
     class Meta:
-        index_name = "PreRegistrationIdIndex"
+        index_name = 'PreRegistrationIdIndex'
         projection = AllProjection()
         read_capacity_units = 1
         write_capacity_units = 1
@@ -21,7 +21,7 @@ class PreRegistrationGlobalSecondaryIndex(GlobalSecondaryIndex):
 
 class EmailLSI(LocalSecondaryIndex):
     class Meta:
-        index_name = "EmailIndex"
+        index_name = 'EmailIndex'
         projection = AllProjection()
         read_capacity_units = 1
         write_capacity_units = 1
@@ -32,9 +32,9 @@ class EmailLSI(LocalSecondaryIndex):
 
 class PreRegistration(Model):
     class Meta:
-        table_name = os.getenv("PREREGISTRATIONS_TABLE")
-        region = os.getenv("REGION")
-        billing_mode = "PAY_PER_REQUEST"
+        table_name = os.getenv('PREREGISTRATIONS_TABLE')
+        region = os.getenv('REGION')
+        billing_mode = 'PAY_PER_REQUEST'
 
     hashKey = UnicodeAttribute(hash_key=True)
     rangeKey = UnicodeAttribute(range_key=True)
@@ -67,51 +67,47 @@ class PreRegistrationaDataIn(BaseModel):
     class Config:
         extra = Extra.ignore
 
-    firstName: str = Field(None, title="First Name")
-    lastName: str = Field(None, title="Last Name")
-    contactNumber: str = Field(None, title="Contact Number")
-    careerStatus: str = Field(None, title="Career Status")
-    yearsOfExperience: str = Field(None, title="Years of Experience")
-    organization: str = Field(None, title="Organization")
-    title: str = Field(None, title="Title")
+    firstName: str = Field(None, title='First Name')
+    lastName: str = Field(None, title='Last Name')
+    contactNumber: str = Field(None, title='Contact Number')
+    careerStatus: str = Field(None, title='Career Status')
+    yearsOfExperience: str = Field(None, title='Years of Experience')
+    organization: str = Field(None, title='Organization')
+    title: str = Field(None, title='Title')
 
 
 class PreRegistrationPatch(PreRegistrationaDataIn):
     class Config:
         extra = Extra.forbid
 
-    acceptanceStatus: Optional[AcceptanceStatus] = Field(
-        None, title="Acceptance Status"
-    )
-    acceptanceEmailSent: bool = Field(None, title="Acceptance Email Sent")
+    acceptanceStatus: Optional[AcceptanceStatus] = Field(None, title='Acceptance Status')
+    acceptanceEmailSent: bool = Field(None, title='Acceptance Email Sent')
 
 
 class PreRegistrationIn(PreRegistrationaDataIn):
     class Config:
         extra = Extra.forbid
 
-    email: EmailStr = Field(None, title="Email")
-    eventId: str = Field(None, title="Event ID")
+    email: EmailStr = Field(None, title='Email')
+    eventId: str = Field(None, title='Event ID')
 
 
 class PreRegistrationOut(PreRegistrationIn):
     class Config:
         extra = Extra.ignore
 
-    preRegistrationId: str = Field(..., title="ID")
-    acceptanceEmailSent: bool = Field(None, title="Acceptance Email Sent")
-    acceptanceStatus: Optional[AcceptanceStatus] = Field(
-        None, title="Acceptance Status"
-    )
-    createDate: datetime = Field(..., title="Created At")
-    updateDate: datetime = Field(..., title="Updated At")
+    preRegistrationId: str = Field(..., title='ID')
+    acceptanceEmailSent: bool = Field(None, title='Acceptance Email Sent')
+    acceptanceStatus: Optional[AcceptanceStatus] = Field(None, title='Acceptance Status')
+    createDate: datetime = Field(..., title='Created At')
+    updateDate: datetime = Field(..., title='Updated At')
 
 
 class PreRegistrationPreviewOut(BaseModel):
     class Config:
         extra = Extra.ignore
 
-    firstName: str = Field(None, title="First Name")
-    lastName: str = Field(None, title="Last Name")
-    contactNumber: str = Field(None, title="Contact Number")
-    email: EmailStr = Field(None, title="Email")
+    firstName: str = Field(None, title='First Name')
+    lastName: str = Field(None, title='Last Name')
+    contactNumber: str = Field(None, title='Contact Number')
+    email: EmailStr = Field(None, title='Email')

--- a/backend/usecase/file_s3_usecase.py
+++ b/backend/usecase/file_s3_usecase.py
@@ -1,7 +1,6 @@
 import os
 from typing import Tuple
 
-from http import HTTPStatus
 from boto3 import client as boto3_client
 from botocore.config import Config
 from botocore.exceptions import ClientError

--- a/backend/usecase/file_s3_usecase.py
+++ b/backend/usecase/file_s3_usecase.py
@@ -68,8 +68,6 @@ class FileS3Usecase:
             return None
 
     def upload_file(self, file_name: str, object_name: str = None, verbose: bool = True) -> bool:
-        result = True
-
         # If S3 object_name was not specified, use file_name
         if object_name is None:
             object_name = file_name

--- a/backend/usecase/file_s3_usecase.py
+++ b/backend/usecase/file_s3_usecase.py
@@ -75,11 +75,10 @@ class FileS3Usecase:
         try:
             self.__s3_client.upload_file(file_name, self.__bucket, object_name)
             if verbose:
-                logger.info('Stored file in S3: %s/%s', self.__bucket, object_name)
+                logger.info(f'Stored file in S3: {self.__bucket}/{object_name}')
         except Exception as e:
             message = f'Failed to upload file ({file_name}) to S3, Reason: {type(e).__name__} - {str(e)}'
             logger.error(message)
-            # raise PdfServiceInternalError(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, message=message) from e
 
     def get_values_from_object_key(self, object_key) -> Tuple[str, str]:
         """Get the entry id and upload type from the object key

--- a/backend/usecase/preregistration_usecase.py
+++ b/backend/usecase/preregistration_usecase.py
@@ -271,8 +271,7 @@ class PreRegistrationUsecase:
         status, preregistrations, message = self.__preregistrations_repository.query_preregistrations(event_id=event_id)
 
         if status != HTTPStatus.OK:
-            logger.error(message)
-            return
+            return JSONResponse(status_code=status, content={'message': message})
 
         try:
             with tempfile.TemporaryDirectory() as tmpdir:

--- a/backend/usecase/preregistration_usecase.py
+++ b/backend/usecase/preregistration_usecase.py
@@ -1,6 +1,7 @@
 import json, tempfile, csv, os
 from http import HTTPStatus
 from typing import List, Union
+from model.file_uploads.file_upload import FileDownloadOut
 from utils.logger import logger
 
 import ulid
@@ -276,13 +277,14 @@ class PreRegistrationUsecase:
 
         return None
 
-    def get_preregistration_csv(self, event_id: str):
-        """
+    def get_preregistration_csv(self, event_id: str) -> FileDownloadOut:
+        """Returns the FileDownloadOut of the CSV for the specified event
+
         :param event_id: The event pre-registrations to be queried
         :type event_id: str
 
-        :return: URL to S3 bucket
-        :rtype: str
+        :return: FileDownloadOut for the CSV
+        :rtype: FileDownloadOut
         """
         # Get preregistrations for an event
         status, preregistrations, message = (
@@ -297,9 +299,11 @@ class PreRegistrationUsecase:
             with tempfile.TemporaryDirectory() as tmpdir:
                 csv_path = os.path.join(tmpdir, "preregistrations.csv")
 
-                # ...
+                with open("preregistrations.csv", "w") as temp:
+                    writer = csv.writer(temp)
+                    writer.writerows(entry.__fields__ for entry in preregistrations)
 
-                self.__s3_usecase.create_download_url(csv_path)
+                return self.__s3_usecase.create_download_url(csv_path)
 
         except Exception as e:
             logger.error(f"Error generating the CSV: {e}")

--- a/backend/usecase/preregistration_usecase.py
+++ b/backend/usecase/preregistration_usecase.py
@@ -1,6 +1,7 @@
-import json
+import json, tempfile, csv, os
 from http import HTTPStatus
 from typing import List, Union
+from utils.logger import logger
 
 import ulid
 from model.events.events_constants import EventStatus
@@ -13,6 +14,7 @@ from repository.events_repository import EventsRepository
 from repository.preregistrations_repository import PreRegistrationsRepository
 from starlette.responses import JSONResponse
 from usecase.email_usecase import EmailUsecase
+from usecase.file_s3_usecase import FileS3Usecase
 
 
 class PreRegistrationUsecase:
@@ -29,8 +31,11 @@ class PreRegistrationUsecase:
         self.__preregistrations_repository = PreRegistrationsRepository()
         self.__events_repository = EventsRepository()
         self.__email_usecase = EmailUsecase()
+        self.__s3_usecase = FileS3Usecase()
 
-    def create_preregistration(self, preregistration_in: PreRegistrationIn) -> Union[JSONResponse, PreRegistrationOut]:
+    def create_preregistration(
+        self, preregistration_in: PreRegistrationIn
+    ) -> Union[JSONResponse, PreRegistrationOut]:
         """Creates a new pre-registration entry.
 
         :param preregistration_in: The data for creating the new pre-registration.
@@ -40,16 +45,18 @@ class PreRegistrationUsecase:
         :rtype: Union[JSONResponse, PreRegistrationOut]
 
         """
-        status, event, message = self.__events_repository.query_events(event_id=preregistration_in.eventId)
+        status, event, message = self.__events_repository.query_events(
+            event_id=preregistration_in.eventId
+        )
         if status != HTTPStatus.OK:
-            return JSONResponse(status_code=status, content={'message': message})
+            return JSONResponse(status_code=status, content={"message": message})
 
         is_preregistration = event.status == EventStatus.PRE_REGISTRATION.value
         # Check if the event is open for pre-registration
         if not (event.isApprovalFlow and is_preregistration):
             return JSONResponse(
                 status_code=HTTPStatus.BAD_REQUEST,
-                content={'message': 'Event is not open for pre-registration'},
+                content={"message": "Event is not open for pre-registration"},
             )
 
         # Check if the pre-registration with the same email already exists
@@ -59,11 +66,15 @@ class PreRegistrationUsecase:
             status,
             preregistrations,
             message,
-        ) = self.__preregistrations_repository.query_preregistrations_with_email(event_id=event_id, email=email)
+        ) = self.__preregistrations_repository.query_preregistrations_with_email(
+            event_id=event_id, email=email
+        )
         if status == HTTPStatus.OK and preregistrations:
             return JSONResponse(
                 status_code=HTTPStatus.CONFLICT,
-                content={'message': f'Pre-registration with email {email} already exists'},
+                content={
+                    "message": f"Pre-registration with email {email} already exists"
+                },
             )
 
         preregistration_id = ulid.ulid()
@@ -76,18 +87,23 @@ class PreRegistrationUsecase:
             preregistration_in=preregistration_in, preregistration_id=preregistration_id
         )
         if status != HTTPStatus.OK:
-            return JSONResponse(status_code=status, content={'message': message})
+            return JSONResponse(status_code=status, content={"message": message})
 
         preregistration_data = self.__convert_data_entry_to_dict(preregistration)
 
         if not preregistration.preRegistrationEmailSent:
-            self.__email_usecase.send_preregistration_creation_email(preregistration=preregistration, event=event)
+            self.__email_usecase.send_preregistration_creation_email(
+                preregistration=preregistration, event=event
+            )
 
         preregistration_out = PreRegistrationOut(**preregistration_data)
         return preregistration_out
 
     def update_preregistration(
-        self, event_id: str, preregistration_id: str, preregistration_in: PreRegistrationPatch
+        self,
+        event_id: str,
+        preregistration_id: str,
+        preregistration_in: PreRegistrationPatch,
     ) -> Union[JSONResponse, PreRegistrationOut]:
         """Updates an existing pre-registration entry.
 
@@ -101,9 +117,11 @@ class PreRegistrationUsecase:
         :rtype: Union[JSONResponse, PreRegistrationOut]
 
         """
-        status, event, message = self.__events_repository.query_events(event_id=event_id)
+        status, event, message = self.__events_repository.query_events(
+            event_id=event_id
+        )
         if status != HTTPStatus.OK:
-            return JSONResponse(status_code=status, content={'message': message})
+            return JSONResponse(status_code=status, content={"message": message})
 
         (
             status,
@@ -113,7 +131,7 @@ class PreRegistrationUsecase:
             event_id=event_id, preregistration_id=preregistration_id
         )
         if status != HTTPStatus.OK:
-            return JSONResponse(status_code=status, content={'message': message})
+            return JSONResponse(status_code=status, content={"message": message})
 
         (
             status,
@@ -123,14 +141,16 @@ class PreRegistrationUsecase:
             preregistration_entry=preregistration, preregistration_in=preregistration_in
         )
         if status != HTTPStatus.OK:
-            return JSONResponse(status_code=status, content={'message': message})
+            return JSONResponse(status_code=status, content={"message": message})
 
         preregistration_data = self.__convert_data_entry_to_dict(update_preregistration)
         preregistration_out = PreRegistrationOut(**preregistration_data)
 
         return preregistration_out
 
-    def get_preregistration(self, event_id: str, preregistration_id: str) -> Union[JSONResponse, PreRegistrationOut]:
+    def get_preregistration(
+        self, event_id: str, preregistration_id: str
+    ) -> Union[JSONResponse, PreRegistrationOut]:
         """Retrieves a specific pre-registration entry by its ID.
 
         :param event_id: The ID of the event
@@ -145,7 +165,7 @@ class PreRegistrationUsecase:
         """
         status, _, message = self.__events_repository.query_events(event_id=event_id)
         if status != HTTPStatus.OK:
-            return JSONResponse(status_code=status, content={'message': message})
+            return JSONResponse(status_code=status, content={"message": message})
 
         (
             status,
@@ -155,12 +175,14 @@ class PreRegistrationUsecase:
             event_id=event_id, preregistration_id=preregistration_id
         )
         if status != HTTPStatus.OK:
-            return JSONResponse(status_code=status, content={'message': message})
+            return JSONResponse(status_code=status, content={"message": message})
 
         preregistration_data = self.__convert_data_entry_to_dict(preregistration)
         return PreRegistrationOut(**preregistration_data)
 
-    def get_preregistration_by_email(self, event_id: str, email: str) -> PreRegistrationOut:
+    def get_preregistration_by_email(
+        self, event_id: str, email: str
+    ) -> PreRegistrationOut:
         """Retrieves a specific pre-registration entry by its email.
 
         :param event_id: The ID of the event
@@ -177,16 +199,20 @@ class PreRegistrationUsecase:
             status,
             preregistrations,
             message,
-        ) = self.__preregistrations_repository.query_preregistrations_with_email(event_id=event_id, email=email)
+        ) = self.__preregistrations_repository.query_preregistrations_with_email(
+            event_id=event_id, email=email
+        )
         if status != HTTPStatus.OK or not preregistrations:
-            return JSONResponse(status_code=status, content={'message': message})
+            return JSONResponse(status_code=status, content={"message": message})
 
         preregistration = preregistrations[0]
         preregistration_data = self.__convert_data_entry_to_dict(preregistration)
 
         return PreRegistrationOut(**preregistration_data)
 
-    def get_preregistrations(self, event_id: str = None) -> Union[JSONResponse, List[PreRegistrationOut]]:
+    def get_preregistrations(
+        self, event_id: str = None
+    ) -> Union[JSONResponse, List[PreRegistrationOut]]:
         """Retrieves a list of pre-registration preregistration_entries.
 
         :param event_id: If provided, only retrieves pre-registration entries for the specified event. If not provided, retrieves all pre-registration entries.
@@ -198,7 +224,7 @@ class PreRegistrationUsecase:
         """
         status, _, message = self.__events_repository.query_events(event_id=event_id)
         if status != HTTPStatus.OK:
-            return JSONResponse(status_code=status, content={'message': message})
+            return JSONResponse(status_code=status, content={"message": message})
 
         (
             status,
@@ -206,14 +232,16 @@ class PreRegistrationUsecase:
             message,
         ) = self.__preregistrations_repository.query_preregistrations(event_id=event_id)
         if status != HTTPStatus.OK:
-            return JSONResponse(status_code=status, content={'messsage': message})
+            return JSONResponse(status_code=status, content={"messsage": message})
 
         return [
             PreRegistrationOut(**self.__convert_data_entry_to_dict(preregistration))
             for preregistration in preregistrations
         ]
 
-    def delete_preregistration(self, event_id: str, preregistration_id: str) -> Union[None, JSONResponse]:
+    def delete_preregistration(
+        self, event_id: str, preregistration_id: str
+    ) -> Union[None, JSONResponse]:
         """Deletes a specific preregistration entry by its ID.
 
         :param event_id: The ID of the event
@@ -228,7 +256,7 @@ class PreRegistrationUsecase:
         """
         status, _, message = self.__events_repository.query_events(event_id=event_id)
         if status != HTTPStatus.OK:
-            return JSONResponse(status_code=status, content={'message': message})
+            return JSONResponse(status_code=status, content={"message": message})
 
         (
             status,
@@ -238,15 +266,44 @@ class PreRegistrationUsecase:
             event_id=event_id, preregistration_id=preregistration_id
         )
         if status != HTTPStatus.OK:
-            return JSONResponse(status_code=status, content={'message': message})
+            return JSONResponse(status_code=status, content={"message": message})
 
         status, message = self.__preregistrations_repository.delete_preregistration(
             preregistration_entry=preregistration
         )
         if status != HTTPStatus.OK:
-            return JSONResponse(status_code=status, content={'message': message})
+            return JSONResponse(status_code=status, content={"message": message})
 
         return None
+
+    def get_preregistration_csv(self, event_id: str):
+        """
+        :param event_id: The event pre-registrations to be queried
+        :type event_id: str
+
+        :return: URL to S3 bucket
+        :rtype: str
+        """
+        # Get preregistrations for an event
+        status, preregistrations, message = (
+            self.__preregistrations_repository.query_preregistrations(event_id=event_id)
+        )
+
+        if status != HTTPStatus.OK:
+            logger.error(message)
+            return
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                csv_path = os.path.join(tmpdir, "preregistrations.csv")
+
+                # ...
+
+                self.__s3_usecase.create_download_url(csv_path)
+
+        except Exception as e:
+            logger.error(f"Error generating the CSV: {e}")
+            return
 
     @staticmethod
     def __convert_data_entry_to_dict(data_entry):

--- a/backend/usecase/preregistration_usecase.py
+++ b/backend/usecase/preregistration_usecase.py
@@ -280,12 +280,14 @@ class PreRegistrationUsecase:
                 with open(csv_path, 'w') as temp:
                     writer = csv.writer(temp)
 
-                    # make the first row csv for the keys
-                    writer.writerow(self.__convert_data_entry_to_dict(preregistrations[0]).keys())
+                    # make the first row csv for the keys using the dict keys of the first entry
+                    first_entry = self.__convert_data_entry_to_dict(preregistrations[0])
+                    writer.writerow(first_entry.keys())
 
                     # the remaining rows consist of the values of the attributes
                     for entry in preregistrations:
-                        writer.writerow(self.__convert_data_entry_to_dict(entry).values())
+                        entry_dict = self.__convert_data_entry_to_dict(entry)
+                        writer.writerow(entry_dict.values())
 
                 # upload the file to s3
                 csv_object_key = f'csv/preregistrations/{event_id}.csv'
@@ -294,7 +296,7 @@ class PreRegistrationUsecase:
                 return self.__file_s3_usecase.create_download_url(csv_object_key)
 
         except Exception as e:
-            logger.error(f'Error generating the CSV: {e}')
+            logger.error(f'Error generating the CSV for {event_id}: {e}')
             return
 
     @staticmethod

--- a/backend/usecase/preregistration_usecase.py
+++ b/backend/usecase/preregistration_usecase.py
@@ -301,7 +301,13 @@ class PreRegistrationUsecase:
 
                 with open("preregistrations.csv", "w") as temp:
                     writer = csv.writer(temp)
-                    writer.writerows(entry.__fields__ for entry in preregistrations)
+
+                    # make the first row csv for the keys
+                    writer.writerow(preregistrations[0].get_attributes().keys())
+
+                    # the remaining rows consist of the values of the attributes
+                    for entry in preregistrations:
+                        writer.writerow(entry.get_attributes().values())
 
                 return self.__s3_usecase.create_download_url(csv_path)
 

--- a/backend/usecase/registration_usecase.py
+++ b/backend/usecase/registration_usecase.py
@@ -1,18 +1,17 @@
-import json
-import tempfile
 import csv
+import json
 import os
+import tempfile
 from http import HTTPStatus
 from typing import List, Union
-from utils.logger import logger
 
 import ulid
 from constants.common_constants import CommonConstants
 from external_gateway.konfhub_gateway import KonfHubGateway
 from model.events.event import Event
 from model.events.events_constants import EventStatus
-from model.konfhub.konfhub import KonfHubCaptureRegistrationIn, RegistrationDetail
 from model.file_uploads.file_upload import FileDownloadOut
+from model.konfhub.konfhub import KonfHubCaptureRegistrationIn, RegistrationDetail
 from model.registrations.registration import (
     PreRegistrationToRegistrationIn,
     RegistrationIn,
@@ -28,6 +27,7 @@ from usecase.discount_usecase import DiscountUsecase
 from usecase.email_usecase import EmailUsecase
 from usecase.file_s3_usecase import FileS3Usecase
 from usecase.preregistration_usecase import PreRegistrationUsecase
+from utils.logger import logger
 
 
 class RegistrationUsecase:

--- a/backend/usecase/registration_usecase.py
+++ b/backend/usecase/registration_usecase.py
@@ -410,12 +410,14 @@ class RegistrationUsecase:
                 with open(csv_path, 'w') as temp:
                     writer = csv.writer(temp)
 
-                    # make the first row csv for the keys
-                    writer.writerow(self.__convert_data_entry_to_dict(registrations[0]).keys())
+                    # make the first row csv for the keys using the dict keys of the first entry
+                    first_entry = self.__convert_data_entry_to_dict(registrations[0])
+                    writer.writerow(first_entry.keys())
 
                     # the remaining rows consist of the values of the attributes
                     for entry in registrations:
-                        writer.writerow(self.__convert_data_entry_to_dict(entry).values())
+                        entry_dict = self.__convert_data_entry_to_dict(entry)
+                        writer.writerow(entry_dict.values())
 
                 # upload the file to s3
                 csv_object_key = f'csv/registrations/{event_id}.csv'
@@ -424,7 +426,7 @@ class RegistrationUsecase:
                 return self.__file_s3_usecase.create_download_url(csv_object_key)
 
         except Exception as e:
-            logger.error(f'Error generating the CSV: {e}')
+            logger.error(f'Error generating the CSV for {event_id}: {e}')
             return
 
     def delete_registration(self, event_id: str, registration_id: str) -> Union[None, JSONResponse]:


### PR DESCRIPTION
Use `GET preregistrations/{eventId}/csv_download` and `GET registrations/{eventId}/csv_download` to get a JSON containing the download url from S3 and object key. 

> Raises 404 on non-existent pre-registrations.